### PR TITLE
Prevent unnecessary null block if image is already aligned

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function (chunkSize, opts) {
     if (flush) {
         flushFunction = function (next) {
 
-            if (opts.align) {
+            if (opts.align && buffer.length > 0) {
               var remaining = new Buffer(chunkSize - buffer.length);
               remaining.fill(0);
               buffer = Buffer.concat([ buffer, remaining ], chunkSize);

--- a/test/flush.js
+++ b/test/flush.js
@@ -41,7 +41,8 @@ test('Test flush option', function (t) {
 });
 
 test('Test align option', function (t) {
-    t.plan(1);
+
+    t.plan(2);
 
     var optsFlushAlign = {
         flush: true,
@@ -59,5 +60,15 @@ test('Test align option', function (t) {
     chunkerFlushAlign.write('34');
     chunkerFlushAlign.write('5');
     chunkerFlushAlign.end();
+
+    function checkAlignedFlushAlign(data) {
+        t.equals(data, '1234', 'Received flush data');
+    }
+    var chunkerAlignedFlushAlign = Chunker(4, optsFlushAlign);
+    var concatStreamAlignedFlushAlign = concat(checkAlignedFlushAlign);
+    chunkerAlignedFlushAlign.pipe(concatStreamAlignedFlushAlign);
+    chunkerAlignedFlushAlign.write('12');
+    chunkerAlignedFlushAlign.write('34');
+    chunkerAlignedFlushAlign.end();
 
 });


### PR DESCRIPTION
If the user makes use of the `align` option but the image is already
aligned, the module will append a whole null chunk independently on
whether there is remaining data to flush or not.

This PR checks the remaining data buffer length, and only runs the
alignment routine if there is really something to align.

In the test case added below, the result was `1234\0\0\0\0`. `1234` is
already aligned in 4 bytes chunks, but the code adds 4 null bytes at the
end anyway.

Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
